### PR TITLE
Improve contrast on Contrast (Dark) theme

### DIFF
--- a/core/palettes/ContrastDark.tid
+++ b/core/palettes/ContrastDark.tid
@@ -1,6 +1,6 @@
-title: $:/palettes/ContrastLight
-name: Contrast (Light)
-description: High contrast and unambiguous (light version)
+title: $:/palettes/ContrastDark
+name: Contrast (Dark)
+description: High contrast and unambiguous (dark version)
 tags: $:/tags/Palette
 type: application/x-tiddler-dictionary
 
@@ -30,8 +30,8 @@ external-link-background-hover: inherit
 external-link-background-visited: inherit
 external-link-background: inherit
 external-link-foreground-hover: inherit
-external-link-foreground-visited: #00a
-external-link-foreground: #00e
+external-link-foreground-visited: #aa0
+external-link-foreground: #ee0
 foreground: #000
 message-background: <<colour foreground>>
 message-border: <<colour background>>
@@ -48,7 +48,7 @@ notification-border: <<colour foreground>>
 page-background: <<colour background>>
 pre-background: <<colour background>>
 pre-border: <<colour foreground>>
-primary: #00f
+primary: #ff0
 select-tag-background:
 select-tag-foreground:
 sidebar-button-foreground: <<colour foreground>>


### PR DESCRIPTION
Use yellow instead of blue for links, which does not contrast well against black. Many colors will be an improvement, I just picked the one that's the inverse of blue because it was suitable and easy.

Also updated the fields in the file to match the name of the file.